### PR TITLE
Sql prepared statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+* added support for Go modules
+* added support for SQL
 
 ## [0.4.0] - 2021-08-01
 ### Changed

--- a/README.md
+++ b/README.md
@@ -45,12 +45,12 @@ func main(){
 package main
 
 import (
+	"log"
 
-"github.com/rbicker/go-rsql"
-"log"
+	"github.com/rbicker/go-rsql"
 )
 
-func main(){
+func main() {
 	parser, err := rsql.NewParser(rsql.SQL())
 	if err != nil {
 		log.Fatalf("error while creating parser: %s", err)
@@ -61,7 +61,21 @@ func main(){
 		log.Fatalf("error while parsing: %s", err)
 	}
 	log.Println(res)
-	// { "$or": [ { "status": "A" }, { "qty": { "$lt": 30 } } ] }
+	// status = "A" OR qty < 30
+
+	// example use
+	// The 1=1 allows us to add or not add more conditions. It shouldn't affect
+	// query run times.
+	qry := "SELECT * FROM books WHERE 1=1"
+	// This example is simplified. but in a real world example you may not
+	// have a url query string and res will be empty.
+	if res != "" {
+		// The parentheses may not be necessary but they help ensure the order
+		// of operations.
+		qry += " AND (" + res + ")"
+	}
+
+	log.Println(qry)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-go-rsql
-=======
+# go-rsql
 
-# overview
+## overview
+
 RSQL is a query language for parametrized filtering of entries in APIs. 
 It is based on FIQL (Feed Item Query Language) – an URI-friendly syntax for expressing filters across the entries in an Atom Feed.
 FIQL is great for use in URI; there are no unsafe characters, so URL encoding is not required.
@@ -11,9 +11,10 @@ so RSQL also provides a friendlier syntax for logical operators and some compari
 This is a small RSQL helper library, written in golang.
 It can be used to parse a RSQL string and turn it into a database query string.
 
-Currently, only mongodb is supported out of the box (however it is very easy to extend the parser if needed).
+Currently, mongodb and SQL is supported out of the box. It is very easy to create a new parser if needed.
 
-# basic usage
+## basic usage (mongodb)
+
 ```go
 package main
 
@@ -38,9 +39,35 @@ func main(){
 }
 ```
 
+## basic usage (SQL)
 
-# supported operators
-The library supports the following basic operators by default:
+```go
+package main
+
+import (
+
+"github.com/rbicker/go-rsql"
+"log"
+)
+
+func main(){
+	parser, err := rsql.NewParser(rsql.SQL())
+	if err != nil {
+		log.Fatalf("error while creating parser: %s", err)
+	}
+	s := `status=="A",qty=lt=30`
+	res, err := parser.Process(s)
+	if err != nil {
+		log.Fatalf("error while parsing: %s", err)
+	}
+	log.Println(res)
+	// { "$or": [ { "status": "A" }, { "qty": { "$lt": 30 } } ] }
+}
+```
+
+## supported operators
+
+go-rsql supports the following basic operators by default:
 
 | Basic Operator | Description         |
 |----------------|---------------------|
@@ -53,7 +80,7 @@ The library supports the following basic operators by default:
 | =in=           | In                  |
 | =out=          | Not in              |
 
-The following table lists two joining operators:
+go-rsql supports two joining operators:
 
 | Composite Operator | Description         |
 |--------------------|---------------------|
@@ -61,9 +88,10 @@ The following table lists two joining operators:
 | ,                  | Logical OR          |
 
 
-# advanced usage 
+## advanced usage 
 
-## custom operators
+### custom operators
+
 The library makes it easy to define custom operators:
 ```go
 package main
@@ -126,7 +154,8 @@ func main(){
 }
 ```
 
-## transform keys
+### transform keys
+
 If your database key naming scheme is different from the one used in your rsql statements, you can add functions to transform your keys.
 
 ```go
@@ -156,7 +185,8 @@ func main() {
 }
 ```
 
-## define allowed or forbidden keys
+### define allowed or forbidden keys
+
 ```go
 package main
 

--- a/README.md
+++ b/README.md
@@ -64,18 +64,15 @@ func main() {
 	// status = "A" OR qty < 30
 
 	// example use
-	// The 1=1 allows us to add or not add more conditions. It shouldn't affect
-	// query run times.
-	qry := "SELECT * FROM books WHERE 1=1"
+	qry := "SELECT * FROM books"
 	// This example is simplified. but in a real world example you may not
 	// have a url query string and res will be empty.
 	if res != "" {
-		// The parentheses may not be necessary but they help ensure the order
-		// of operations.
-		qry += " AND (" + res + ")"
+		qry += " WHERE " + res
 	}
 
 	log.Println(qry)
+	// SELECT * FROM books WHERE status = "A" OR qty < 30
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -55,13 +55,16 @@ func main() {
 	if err != nil {
 		log.Fatalf("error while creating parser: %s", err)
 	}
-	s := `status=="A",qty=lt=30`
-	res, err := parser.Process(s)
+	s := `status==A,qty=lt=30`
+
+	var args []any
+
+	res, args, err := parser.Process(s)
 	if err != nil {
 		log.Fatalf("error while parsing: %s", err)
 	}
 	log.Println(res)
-	// status = "A" OR qty < 30
+	// status = $1 OR qty < $2
 
 	// example use
 	qry := "SELECT * FROM books"
@@ -72,7 +75,10 @@ func main() {
 	}
 
 	log.Println(qry)
-	// SELECT * FROM books WHERE status = "A" OR qty < 30
+	// SELECT * FROM books WHERE status = $1 OR qty < $2
+
+	log.Println(args)
+	// [A 30]
 }
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/rbicker/go-rsql
+
+go 1.24

--- a/rsql_test.go
+++ b/rsql_test.go
@@ -389,6 +389,197 @@ func TestParser_ProcessMongo(t *testing.T) {
 	}
 }
 
+func TestParser_ProcessSQL(t *testing.T) {
+	tests := []struct {
+		name            string
+		s               string
+		options         []func(*ProcessOptions) error
+		customOperators []Operator
+		keyTransformers []func(s string) string
+		want            string
+		wantErr         bool
+	}{
+		{
+			name: "empty",
+			s:    "",
+			want: "",
+		},
+		{
+			name: "==",
+			s:    "a==1",
+			want: `a = 1`,
+		},
+		{
+			name: "!=",
+			s:    "a!=1",
+			want: `a <> 1`,
+		},
+		{
+			name: "=gt=",
+			s:    "a=gt=1",
+			want: `a > 1`,
+		},
+		{
+			name: "=ge=",
+			s:    "a=ge=1",
+			want: `a >= 1`,
+		},
+		{
+			name: "=lt=",
+			s:    "a=lt=1",
+			want: `a < 1`,
+		},
+		{
+			name: "=le=",
+			s:    "a=le=1",
+			want: `a <= 1`,
+		},
+		{
+			name: "=in=",
+			s:    "a=in=(1,2,3)",
+			want: `a IN (1,2,3)`,
+		},
+		{
+			name: "=out=",
+			s:    "a=out=(1,2,3)",
+			want: `a NOT IN (1,2,3)`,
+		},
+		{
+			name: "(a==1)",
+			s:    "(a==1)",
+			want: `a = 1`,
+		},
+		{
+			name: "a==1;b==2",
+			s:    "a==1;b==2",
+			want: `a = 1 AND b = 2`,
+		},
+		{
+			name: "a==1,b==2",
+			s:    "a==1,b==2",
+			want: `a = 1 OR b = 2`,
+		},
+		{
+			name: "a==1;b==2,c==1",
+			s:    "a==1;b==2,c==1",
+			want: `(a = 1 AND b = 2) OR c = 1`,
+		},
+		{
+			name: "a==1,b==2;c==1",
+			s:    "a==1,b==2;c==1",
+			want: `a = 1 OR (b = 2 AND c = 1)`,
+		},
+		{
+			name: "(a==1;b==2),c=gt=5",
+			s:    "(a==1;b==2),c=gt=5",
+			want: `(a = 1 AND b = 2) OR c > 5`,
+		},
+		{
+			name: "c==1,(a==1;b==2)",
+			s:    "c==1,(a==1;b==2)",
+			want: `c = 1 OR (a = 1 AND b = 2)`,
+		},
+		{
+			name: "a==1;(b==1,c==2)",
+			s:    "a==1;(b==1,c==2)",
+			want: `a = 1 AND (b = 1 OR c = 2)`,
+		},
+		{
+			name: "(a==1,b==1);(c==1,d==2)",
+			s:    "(a==1,b==1);(c==1,d==2)",
+			want: `(a = 1 OR b = 1) AND (c = 1 OR d = 2)`,
+		},
+		{
+			name: "custom operator: =like=",
+			s:    "a=like=c*",
+			customOperators: []Operator{
+				{
+					Operator: "=like=",
+					Formatter: func(key, value string) string {
+						value = strings.ReplaceAll(value, "*", "%")
+						return fmt.Sprintf(`%s LIKE '%s'`, key, value)
+					},
+				},
+			},
+			want: `a LIKE 'c%'`,
+		},
+		{
+			name:    "all keys allowed",
+			s:       "a==1",
+			options: []func(*ProcessOptions) error{},
+			wantErr: false,
+			want:    `a = 1`,
+		},
+		{
+			name: "key allowed",
+			s:    "a==1",
+			options: []func(*ProcessOptions) error{
+				SetAllowedKeys([]string{"a"}),
+			},
+			wantErr: false,
+			want:    `a = 1`,
+		},
+		{
+			name: "key not allowed",
+			s:    "a==1",
+			options: []func(*ProcessOptions) error{
+				SetAllowedKeys([]string{"b"}),
+			},
+			wantErr: true,
+			want:    "",
+		},
+		{
+			name: "key forbidden",
+			s:    "a==1",
+			options: []func(*ProcessOptions) error{
+				SetForbiddenKeys([]string{"a"}),
+			},
+			wantErr: true,
+			want:    "",
+		},
+		{
+			name: "key not forbidden",
+			s:    "a==1",
+			options: []func(*ProcessOptions) error{
+				SetForbiddenKeys([]string{"b"}),
+			},
+			wantErr: false,
+			want:    `a = 1`,
+		},
+		{
+			name: "uppercase key transformer",
+			s:    "a==1",
+			keyTransformers: []func(s string) string{
+				func(s string) string {
+					return strings.ToUpper(s)
+				},
+			},
+			wantErr: false,
+			want:    `A = 1`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var opts []func(*Parser) error
+			opts = append(opts, SQL())
+			opts = append(opts, WithOperators(tt.customOperators...))
+			opts = append(opts, WithKeyTransformers(tt.keyTransformers...))
+			parser, err := NewParser(opts...)
+			if err != nil {
+				t.Fatalf("error while creating parser: %s", err)
+			}
+			got, err := parser.Process(tt.s, tt.options...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Process() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("Process() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func Test_findParts(t *testing.T) {
 	tests := []struct {
 		name       string


### PR DESCRIPTION
This PR is not ready for merging but I'm adding it in case anyone stumbles on it in the future.
#1 should be merged first.

This PR makes adjustments for prepared statements. passing values directly from urls into sql strings is very dangerous.

Left to do on this PR
- The MongoDB parser does return values but the strings returned need to be adjusted for MongoDBs parameterized queries format. I don't use MongoDB so I'm leaving that bit for others. Though I could take a stab at it if this PR ever gets close to merging.
- SQLs prepared statements format can be different based on the DB. "?" and "$1" off the top of my head but I'd have to look at the major players like sqlite, mysql, postgres, Microsoft SQL Server, Oracle, etc. Might make sense to have a way to pass that in or change. Since I'm using Postgres that is what I coded for.
- readme has to be adjusted for example custom operators

```go
customOperators := []rsql.Operator{
    {
        Operator: "=ilike=",
        Formatter: func(key, value string, paramIndex *int) (string, []any) {
            *paramIndex++
            value = strings.ReplaceAll(value, "*", "%")
            return fmt.Sprintf(`%s ILIKE $%d`, key, *paramIndex), []any{value}
        },
    },
}
```